### PR TITLE
Add syntax highlighting for snippets

### DIFF
--- a/rate.py
+++ b/rate.py
@@ -35,7 +35,7 @@ def loadprint(filename):
 			click.echo(dat[i]['intent'])
 			click.echo(' ')
 			click.echo('The snippet is:')
-			click.echo(hl(dat[i][names[j]]))
+			click.echo(hl(dat[i][names[j]].replace("`", "'")))
 			click.echo(' ')
 			while True:
 				c = click.getchar()

--- a/rate.py
+++ b/rate.py
@@ -2,6 +2,14 @@ import click
 import json
 import os
 import random
+from pygments import highlight
+from pygments.lexers.python import PythonLexer
+from pygments.formatters.terminal import TerminalFormatter
+
+
+def hl(snippet):
+    return highlight(snippet, PythonLexer(), TerminalFormatter())
+
 
 @click.command()
 @click.option('--filename', default='./to-grade/all-singles.json', help='JSON dataset of code snippets to be rated')
@@ -27,7 +35,7 @@ def loadprint(filename):
 			click.echo(dat[i]['intent'])
 			click.echo(' ')
 			click.echo('The snippet is:')
-			click.echo(dat[i][names[j]])
+			click.echo(hl(dat[i][names[j]]))
 			click.echo(' ')
 			while True:
 				c = click.getchar()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+click==7.1.2
+Pygments==2.6.1


### PR DESCRIPTION
Use pygments to add syntax highlighting. Works for most snippets.

While this helps with readability — I find it much easier to make sense of a snippet with highlighting — lack of highlighting for a snippet could give a hint about its quality. Not sure if it's a big issue. What do you think?